### PR TITLE
Fix getColor hex usage

### DIFF
--- a/FUI-Views/FUI-Views/Helpers/Colors.swift
+++ b/FUI-Views/FUI-Views/Helpers/Colors.swift
@@ -57,7 +57,7 @@ public enum ColorName: String {
 }
 
 public func getColor(hex: String) -> Color {
-    return Color(UIColor(hex: "hex"))
+    return Color(UIColor(hex: hex))
 }
 
 // Function to create UIColor from hex string


### PR DESCRIPTION
## Summary
- fix `getColor(hex:)` to pass through the hex string

## Testing
- `swift test` *(fails: Could not find Package.swift)*