### PR TITLE
Add futureScape unit test

### DIFF
--- a/FUI-Views/FUI-ViewsTests/FUI_ViewsTests.swift
+++ b/FUI-Views/FUI-ViewsTests/FUI_ViewsTests.swift
@@ -14,4 +14,11 @@ struct FUI_ViewsTests {
         // Write your test here and use APIs like `#expect(...)` to check expected conditions.
     }
 
+    @Test func testFutureScapeReturnsSubstitutions() async throws {
+        let result = futureScape("ab7")
+        #expect(result.contains("\u{00DF}"))
+        #expect(result.contains("\u{E002}"))
+        #expect(result == "A\u{00DF}\u{E002}")
+    }
+
 }


### PR DESCRIPTION
## Summary
- add a test verifying symbol substitutions in `futureScape`

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*