### PR TITLE
Fix color hex helper

### DIFF
--- a/FUI-Views/FUI-Views/Helpers/Colors.swift
+++ b/FUI-Views/FUI-Views/Helpers/Colors.swift
@@ -57,7 +57,7 @@ public enum ColorName: String {
 }
 
 public func getColor(hex: String) -> Color {
-    return Color(UIColor(hex: "hex"))
+    return Color(UIColor(hex: hex))
 }
 
 // Function to create UIColor from hex string


### PR DESCRIPTION
## Summary
- fix `getColor` helper to use the passed hex value

## Testing
- `swiftc FUI-Views/FUI-Views/Helpers/Colors.swift -o /tmp/test_colors` *(fails: no such module 'SwiftUI')*