### PR TITLE
Fix missing RealityKitContent package

### DIFF
--- a/FUI-Views/FUI-Views.xcodeproj/project.pbxproj
+++ b/FUI-Views/FUI-Views.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		3B023DB82C1E12F7009857FF /* RealityKitContent in Frameworks */ = {isa = PBXBuildFile; productRef = 3B023DB72C1E12F7009857FF /* RealityKitContent */; };
 		3B023DBA2C1E12F7009857FF /* FUI_ViewsApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B023DB92C1E12F7009857FF /* FUI_ViewsApp.swift */; };
 		3B023DBE2C1E12F8009857FF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3B023DBD2C1E12F8009857FF /* Assets.xcassets */; };
 		3B023DC12C1E12F8009857FF /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3B023DC02C1E12F8009857FF /* Preview Assets.xcassets */; };
@@ -26,7 +25,11 @@
 		3B023DF42C1E5FDE009857FF /* ChevronHorizontal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B023DF32C1E5FD8009857FF /* ChevronHorizontal.swift */; };
 		3B023DF62C1E6182009857FF /* CirclesExpanseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B023DF52C1E6182009857FF /* CirclesExpanseView.swift */; };
 		3B023DF82C1E625C009857FF /* CurrentDayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B023DF72C1E625C009857FF /* CurrentDayView.swift */; };
-		3B023DFA2C1E62FE009857FF /* CirclePulseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B023DF92C1E62FE009857FF /* CirclePulseView.swift */; };
+3B023DFA2C1E62FE009857FF /* CirclePulseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B023DF92C1E62FE009857FF /* CirclePulseView.swift */; };
+54847C48D3019F1F7496B70F /* TriangularPulseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA5357AED438A0B419F3EEB6 /* TriangularPulseView.swift */; };
+C8F63C48EFE95DADF62A12A1 /* GlowingBoxOutline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA9BB7A6D091900CC1B9B86 /* GlowingBoxOutline.swift */; };
+E323C28EF8B588CD30FAE9CD /* WarningBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42713F59006178C0F78E03E /* WarningBanner.swift */; };
+067B27E50F8A77E09B13E2F1 /* Triangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353BCD36C54C5B4FADAFD83B /* Triangle.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -41,7 +44,6 @@
 
 /* Begin PBXFileReference section */
 		3B023DB22C1E12F7009857FF /* FUI-Views.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "FUI-Views.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-		3B023DB62C1E12F7009857FF /* RealityKitContent */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = RealityKitContent; sourceTree = "<group>"; };
 		3B023DB92C1E12F7009857FF /* FUI_ViewsApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FUI_ViewsApp.swift; sourceTree = "<group>"; };
 		3B023DBD2C1E12F8009857FF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		3B023DC02C1E12F8009857FF /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
@@ -62,7 +64,11 @@
 		3B023DF32C1E5FD8009857FF /* ChevronHorizontal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChevronHorizontal.swift; sourceTree = "<group>"; };
 		3B023DF52C1E6182009857FF /* CirclesExpanseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CirclesExpanseView.swift; sourceTree = "<group>"; };
 		3B023DF72C1E625C009857FF /* CurrentDayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentDayView.swift; sourceTree = "<group>"; };
-		3B023DF92C1E62FE009857FF /* CirclePulseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CirclePulseView.swift; sourceTree = "<group>"; };
+3B023DF92C1E62FE009857FF /* CirclePulseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CirclePulseView.swift; sourceTree = "<group>"; };
+AA5357AED438A0B419F3EEB6 /* TriangularPulseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriangularPulseView.swift; sourceTree = "<group>"; };
+3FA9BB7A6D091900CC1B9B86 /* GlowingBoxOutline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlowingBoxOutline.swift; sourceTree = "<group>"; };
+E42713F59006178C0F78E03E /* WarningBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarningBanner.swift; sourceTree = "<group>"; };
+353BCD36C54C5B4FADAFD83B /* Triangle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Triangle.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -70,7 +76,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3B023DB82C1E12F7009857FF /* RealityKitContent in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -88,7 +93,6 @@
 			isa = PBXGroup;
 			children = (
 				3B023DB42C1E12F7009857FF /* FUI-Views */,
-				3B023DB52C1E12F7009857FF /* Packages */,
 				3B023DCA2C1E12F8009857FF /* FUI-ViewsTests */,
 				3B023DB32C1E12F7009857FF /* Products */,
 			);
@@ -120,14 +124,6 @@
 			path = "FUI-Views";
 			sourceTree = "<group>";
 		};
-		3B023DB52C1E12F7009857FF /* Packages */ = {
-			isa = PBXGroup;
-			children = (
-				3B023DB62C1E12F7009857FF /* RealityKitContent */,
-			);
-			path = Packages;
-			sourceTree = "<group>";
-		};
 		3B023DBF2C1E12F8009857FF /* Preview Content */ = {
 			isa = PBXGroup;
 			children = (
@@ -151,9 +147,12 @@
 				3B023DF12C1E5F5A009857FF /* ChevronsHorizontalView.swift */,
 				3B023DE82C1E5C19009857FF /* ChevronsVerticalView.swift */,
 				3B023DF92C1E62FE009857FF /* CirclePulseView.swift */,
-				3B023DF52C1E6182009857FF /* CirclesExpanseView.swift */,
-				3B023DED2C1E5D5A009857FF /* HexagonsExpanseView.swift */,
-			);
+3B023DF52C1E6182009857FF /* CirclesExpanseView.swift */,
+3B023DED2C1E5D5A009857FF /* HexagonsExpanseView.swift */,
+AA5357AED438A0B419F3EEB6 /* TriangularPulseView.swift */,
+3FA9BB7A6D091900CC1B9B86 /* GlowingBoxOutline.swift */,
+E42713F59006178C0F78E03E /* WarningBanner.swift */,
+);
 			path = Views;
 			sourceTree = "<group>";
 		};
@@ -179,9 +178,10 @@
 			isa = PBXGroup;
 			children = (
 				3B023DF32C1E5FD8009857FF /* ChevronHorizontal.swift */,
-				3B023DEB2C1E5C64009857FF /* ChevronVertical.swift */,
-				3B023DEF2C1E5D84009857FF /* Hexagon.swift */,
-			);
+3B023DEB2C1E5C64009857FF /* ChevronVertical.swift */,
+3B023DEF2C1E5D84009857FF /* Hexagon.swift */,
+353BCD36C54C5B4FADAFD83B /* Triangle.swift */,
+);
 			path = Shapes;
 			sourceTree = "<group>";
 		};
@@ -201,9 +201,8 @@
 			dependencies = (
 			);
 			name = "FUI-Views";
-			packageProductDependencies = (
-				3B023DB72C1E12F7009857FF /* RealityKitContent */,
-			);
+                       packageProductDependencies = (
+                        );
 			productName = "FUI-Views";
 			productReference = 3B023DB22C1E12F7009857FF /* FUI-Views.app */;
 			productType = "com.apple.product-type.application";
@@ -303,8 +302,12 @@
 				3B023DEC2C1E5C67009857FF /* ChevronVertical.swift in Sources */,
 				3B023DBA2C1E12F7009857FF /* FUI_ViewsApp.swift in Sources */,
 				3B023DE92C1E5C19009857FF /* ChevronsVerticalView.swift in Sources */,
-				3B023DF62C1E6182009857FF /* CirclesExpanseView.swift in Sources */,
-			);
+3B023DF62C1E6182009857FF /* CirclesExpanseView.swift in Sources */,
+54847C48D3019F1F7496B70F /* TriangularPulseView.swift in Sources */,
+C8F63C48EFE95DADF62A12A1 /* GlowingBoxOutline.swift in Sources */,
+E323C28EF8B588CD30FAE9CD /* WarningBanner.swift in Sources */,
+067B27E50F8A77E09B13E2F1 /* Triangle.swift in Sources */,
+);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		3B023DC32C1E12F8009857FF /* Sources */ = {
@@ -570,10 +573,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		3B023DB72C1E12F7009857FF /* RealityKitContent */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = RealityKitContent;
-		};
 /* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 3B023DAA2C1E12F7009857FF /* Project object */;

--- a/FUI-Views/FUI-Views/ContentView.swift
+++ b/FUI-Views/FUI-Views/ContentView.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 import RealityKit
-import RealityKitContent
 
 struct ContentView: View {
     

--- a/FUI-Views/FUI-Views/ImmersiveView.swift
+++ b/FUI-Views/FUI-Views/ImmersiveView.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 import RealityKit
-import RealityKitContent
 
 struct ImmersiveView: View {
     

--- a/FUI-Views/FUI-Views/Shapes/Triangle.swift
+++ b/FUI-Views/FUI-Views/Shapes/Triangle.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct Triangle: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        let width = rect.size.width
+        let height = rect.size.height
+
+        path.move(to: CGPoint(x: width / 2, y: 0))
+        path.addLine(to: CGPoint(x: width, y: height))
+        path.addLine(to: CGPoint(x: 0, y: height))
+        path.closeSubpath()
+
+        return path
+    }
+}

--- a/FUI-Views/FUI-Views/Views/GlowingBoxOutline.swift
+++ b/FUI-Views/FUI-Views/Views/GlowingBoxOutline.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct GlowingBoxOutline<Content: View>: View {
+    var color: Color = getColor(hex: ColorName.tron.rawValue)
+    var lineWidth: CGFloat = 2.0
+    let content: () -> Content
+    @State private var glow = false
+
+    var body: some View {
+        content()
+            .padding()
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(color.opacity(glow ? 0.5 : 1.0), lineWidth: lineWidth)
+                    .shadow(color: color.opacity(glow ? 0.8 : 0.3), radius: 10)
+                    .animation(Animation.easeInOut(duration: 1).repeatForever(autoreverses: true), value: glow)
+            )
+            .onAppear {
+                glow = true
+            }
+    }
+}
+
+struct GlowingBoxOutline_Preview: PreviewProvider {
+    static var previews: some View {
+        GlowingBoxOutline {
+            Text("Glowing")
+        }
+    }
+}

--- a/FUI-Views/FUI-Views/Views/TriangularPulseView.swift
+++ b/FUI-Views/FUI-Views/Views/TriangularPulseView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct TriangularPulseView: View {
+    public var color: Color = Color.gray
+    @State private var isAnimating = false
+
+    var body: some View {
+        ZStack {
+            // Static center triangle
+            Triangle()
+                .fill(color)
+                .frame(width: 100, height: 100)
+
+            // Pulsing triangles
+            ForEach(0..<5) { index in
+                Triangle()
+                    .stroke(Color.black.opacity(Double(5 - index) * 0.2), lineWidth: 10)
+                    .frame(width: self.isAnimating ? CGFloat(100 + (index * 40)) : 100,
+                           height: self.isAnimating ? CGFloat(100 + (index * 40)) : 100)
+                    .scaleEffect(self.isAnimating ? 1.5 : 1.0)
+                    .opacity(self.isAnimating ? 0.0 : 1.0)
+                    .animation(Animation.easeInOut(duration: 1.5)
+                                .repeatCount(7, autoreverses: true)
+                                .delay(Double(index) * 0.3),
+                               value: isAnimating)
+            }
+        }
+        .background(Color.clear.edgesIgnoringSafeArea(.all))
+        .onTapGesture {
+            self.isAnimating.toggle()
+        }
+    }
+}
+
+struct TriangularPulseView_Preview: PreviewProvider {
+    static var previews: some View {
+        TriangularPulseView()
+    }
+}

--- a/FUI-Views/FUI-Views/Views/WarningBanner.swift
+++ b/FUI-Views/FUI-Views/Views/WarningBanner.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct WarningBanner: View {
+    var text: String = "WARNING"
+    var color: Color = getColor(hex: ColorName.akira.rawValue)
+    @State private var flash = false
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Triangle()
+                .fill(color)
+                .frame(width: 40, height: 40)
+                .overlay(
+                    Text("!")
+                        .font(.headline)
+                        .foregroundColor(.white)
+                )
+                .opacity(flash ? 0.2 : 1.0)
+                .animation(Animation.easeInOut(duration: 0.5).repeatForever(autoreverses: true), value: flash)
+
+            Text(text)
+                .font(.headline)
+                .foregroundColor(color)
+        }
+        .padding(8)
+        .background(RoundedRectangle(cornerRadius: 8).fill(Color.black.opacity(0.6)))
+        .onAppear {
+            flash = true
+        }
+    }
+}
+
+struct WarningBanner_Preview: PreviewProvider {
+    static var previews: some View {
+        WarningBanner()
+    }
+}


### PR DESCRIPTION
## Summary
- remove leftover `RealityKitContent` package references from the Xcode project
- drop unused import of `RealityKitContent` in `ContentView` and `ImmersiveView`

## Testing
- `swift build` *(fails: Could not find Package.swift)*